### PR TITLE
fix: add alternative image to the correct object

### DIFF
--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/sax/SaxPageHandler_2018_07_15.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/sax/SaxPageHandler_2018_07_15.java
@@ -659,7 +659,7 @@ public class SaxPageHandler_2018_07_15 extends SaxPageHandler {
 	}
 	
 	/**
-	 * Adds an alternative image to the list of images of the page object. 
+	 * Adds an alternative image to the list of images of the corresponding object.
 	 */
 	private void handleAlternativeImage(Attributes atts) {
 		if (page.getAlternativeImages() == null)
@@ -669,7 +669,17 @@ public class SaxPageHandler_2018_07_15 extends SaxPageHandler {
 		int i;
 		if ((i = atts.getIndex(DefaultXmlNames.ATTR_filename)) >= 0) {
 			img = new AlternativeImage(atts.getValue(i));
-			page.getAlternativeImages().add(img);
+			if(currentGlyph != null) {
+				currentGlyph.getAlternativeImages().add(img);
+			} else if (currentWord != null) {
+				currentWord.getAlternativeImages().add(img);
+			} else if (currentTextLine != null) {
+				currentTextLine.getAlternativeImages().add(img);
+			} else if (currentRegion != null) {
+				currentRegion.getAlternativeImages().add(img);
+			} else {
+				page.getAlternativeImages().add(img);
+			}
 		}
 		else 
 			return;

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/sax/SaxPageHandler_2019_07_15.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/sax/SaxPageHandler_2019_07_15.java
@@ -662,7 +662,7 @@ public class SaxPageHandler_2019_07_15 extends SaxPageHandler {
 	}
 	
 	/**
-	 * Adds an alternative image to the list of images of the page object. 
+	 * Adds an alternative image to the list of images of the corresponding object.
 	 */
 	private void handleAlternativeImage(Attributes atts) {
 		if (page.getAlternativeImages() == null)
@@ -672,7 +672,17 @@ public class SaxPageHandler_2019_07_15 extends SaxPageHandler {
 		int i;
 		if ((i = atts.getIndex(DefaultXmlNames.ATTR_filename)) >= 0) {
 			img = new AlternativeImage(atts.getValue(i));
-			page.getAlternativeImages().add(img);
+			if(currentGlyph != null) {
+				currentGlyph.getAlternativeImages().add(img);
+			} else if (currentWord != null) {
+				currentWord.getAlternativeImages().add(img);
+			} else if (currentTextLine != null) {
+				currentTextLine.getAlternativeImages().add(img);
+			} else if (currentRegion != null) {
+				currentRegion.getAlternativeImages().add(img);
+			} else {
+				page.getAlternativeImages().add(img);
+			}
 		}
 		else 
 			return;


### PR DESCRIPTION
Fixes the following issue:
Since PAGE XML version `2018-07-15` it's allowed to add `AlternativeImage` elements to elements other than `PageType` elements (`TextLineType` / `WordType` / `GlyphType` / `RegionType`) but the parser of these versions currently assigns all `AlternativeImage` elements to the Page object when it encounters them. This should be updated to reflect the aforementioned changes to the schema.