### PR TITLE
fix: add null pointer checks for relations

### DIFF
--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2013_07_15.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2013_07_15.java
@@ -612,10 +612,10 @@ public class XmlPageWriter_2013_07_15 implements XmlPageWriter {
 				//Type
 				addAttribute(relationNode, DefaultXmlNames.ATTR_type, rel.getRelationType().toString());
 				//Custom
-				if (!rel.getCustomField().isEmpty())
+				if (rel.getCustomField() != null && !rel.getCustomField().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_custom, rel.getCustomField());
 				//Comments
-				if (!rel.getComments().isEmpty())
+				if (rel.getComments() != null && !rel.getComments().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_comments, rel.getComments());
 				
 				//Object 1

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2016_07_15.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2016_07_15.java
@@ -627,10 +627,10 @@ public class XmlPageWriter_2016_07_15 implements XmlPageWriter {
 				//Type
 				addAttribute(relationNode, DefaultXmlNames.ATTR_type, rel.getRelationType().toString());
 				//Custom
-				if (!rel.getCustomField().isEmpty())
+				if (rel.getCustomField() != null && !rel.getCustomField().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_custom, rel.getCustomField());
 				//Comments
-				if (!rel.getComments().isEmpty())
+				if (rel.getComments() != null && !rel.getComments().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_comments, rel.getComments());
 				
 				//Object 1

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2017_07_15.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2017_07_15.java
@@ -725,10 +725,10 @@ public class XmlPageWriter_2017_07_15 implements XmlPageWriter {
 				//Type
 				addAttribute(relationNode, DefaultXmlNames.ATTR_type, rel.getRelationType().toString());
 				//Custom
-				if (!rel.getCustomField().isEmpty())
+				if (rel.getCustomField() != null && !rel.getCustomField().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_custom, rel.getCustomField());
 				//Comments
-				if (!rel.getComments().isEmpty())
+				if (rel.getComments() != null && !rel.getComments().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_comments, rel.getComments());
 				
 				//Object 1

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2018_07_15.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2018_07_15.java
@@ -851,10 +851,10 @@ public class XmlPageWriter_2018_07_15 implements XmlPageWriter {
 				//Type
 				addAttribute(relationNode, DefaultXmlNames.ATTR_type, rel.getRelationType().toString());
 				//Custom
-				if (!rel.getCustomField().isEmpty())
+				if (rel.getCustomField() != null && !rel.getCustomField().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_custom, rel.getCustomField());
 				//Comments
-				if (!rel.getComments().isEmpty())
+				if (rel.getComments() != null && !rel.getComments().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_comments, rel.getComments());
 				
 				//Semantic labels

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2019_07_15.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_2019_07_15.java
@@ -858,10 +858,10 @@ public class XmlPageWriter_2019_07_15 implements XmlPageWriter {
 				//Type
 				addAttribute(relationNode, DefaultXmlNames.ATTR_type, rel.getRelationType().toString());
 				//Custom
-				if (!rel.getCustomField().isEmpty())
+				if (rel.getCustomField() != null && !rel.getCustomField().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_custom, rel.getCustomField());
 				//Comments
-				if (!rel.getComments().isEmpty())
+				if (rel.getComments() != null && !rel.getComments().isEmpty())
 					addAttribute(relationNode, DefaultXmlNames.ATTR_comments, rel.getComments());
 				
 				//Semantic labels


### PR DESCRIPTION
Fixes the following issue:
Currently prima-core-libs throws a `NullPointerException` when trying to write a PAGE XML which contains one or several `Relation` elements which don't have the optional `@comments` **and** `@custom` attributes set (e. g. `<Relation id="rel1" type="join">[...]</Relation>`) because of missing null pointer checks.

  